### PR TITLE
Update for Spree 4

### DIFF
--- a/app/assets/javascripts/spree/backend/spree_shopify_importer.js
+++ b/app/assets/javascripts/spree/backend/spree_shopify_importer.js
@@ -1,2 +1,0 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'

--- a/app/assets/javascripts/spree/frontend/spree_shopify_importer.js
+++ b/app/assets/javascripts/spree/frontend/spree_shopify_importer.js
@@ -1,2 +1,0 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/frontend/all.js'

--- a/app/assets/stylesheets/spree/backend/spree_shopify_importer.css
+++ b/app/assets/stylesheets/spree/backend/spree_shopify_importer.css
@@ -1,4 +1,0 @@
-/*
-Placeholder manifest file.
-the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/backend/all.css'
-*/

--- a/app/assets/stylesheets/spree/frontend/spree_shopify_importer.css
+++ b/app/assets/stylesheets/spree/frontend/spree_shopify_importer.css
@@ -1,4 +1,0 @@
-/*
-Placeholder manifest file.
-the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/frontend/all.css'
-*/

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,9 +1,14 @@
-Spree::AppConfiguration.class_eval do
-  preference :shopify_api_key, :string
-  preference :shopify_password, :string
-  preference :shopify_shop_domain, :string
-  preference :shopify_token, :string
-  preference :shopify_rescue_limit, :integer, default: 5
-  preference :shopify_current_credentials, :hash
-  preference :shopify_import_queue, :string, default: 'default'
+module Spree
+  module AppConfigurationDecorator
+    def self.prepended(base)
+      base.preference :shopify_api_key, :string
+      base.preference :shopify_shop_domain, :string
+      base.preference :shopify_token, :string
+      base.preference :shopify_rescue_limit, :integer, default: 5
+      base.preference :shopify_current_credentials, :hash
+      base.preference :shopify_import_queue, :string, default: 'default'
+    end
+  end
 end
+
+::Spree::AppConfiguration.prepend(Spree::AppConfigurationDecorator)

--- a/lib/generators/spree_shopify_importer/install/install_generator.rb
+++ b/lib/generators/spree_shopify_importer/install/install_generator.rb
@@ -4,19 +4,11 @@ module SpreeShopifyImporter
       class_option :auto_run_migrations, type: :boolean, default: false
 
       def add_javascripts
-        append_file('vendor/assets/javascripts/spree/frontend/all.js',
-                    "//= require spree/frontend/spree_shopify_importer\n")
-        append_file('vendor/assets/javascripts/spree/backend/all.js',
-                    "//= require spree/backend/spree_shopify_importer\n")
+        # Not required
       end
 
       def add_stylesheets
-        inject_into_file('vendor/assets/stylesheets/spree/frontend/all.css',
-                         " *= require spree/frontend/spree_shopify_importer\n",
-                         before: %r{\*/}, verbose: true)
-        inject_into_file('vendor/assets/stylesheets/spree/backend/all.css',
-                         " *= require spree/backend/spree_shopify_importer\n",
-                         before: %r{\*/}, verbose: true)
+        # Not required
       end
 
       def add_migrations

--- a/spree_shopify_importer.gemspec
+++ b/spree_shopify_importer.gemspec
@@ -26,8 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 5.0.0'
   s.add_dependency 'curb'
   s.add_dependency 'shopify_api', '>= 4.2.2'
-  s.add_dependency 'spree_address_book', '>= 3.1.0', '< 4.0'
-  s.add_dependency 'spree_core', '>= 3.1.0', '< 4.0'
+  s.add_dependency 'spree_core', '>= 3.1.0', '< 5.0'
   s.add_dependency 'spree_extension'
 
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
- Remove the generator install for css and js in front and backend. (They are not required for this extension as it stands)
- Removed gem requirement of the spree address book, as it was merged into spree 4.
- Changed the preferences from class eval to prepend as per new way of doing things.
- Delete assets folder as there are none to use as per above removing the generator links to now none existent js and css files.

**NOTE:** The Shopify API gem has been updated since this extension was initially released, It might pay to have the extension checked over and see if it needs updating in more depth than this PR offers.
